### PR TITLE
fix: ensure Authorization is part of headers

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1605,7 +1605,7 @@ paths:
         schema:
           type: string
       - description: 'in: authorization'
-        in: query
+        in: header
         name: Authorization
         schema:
           type: string


### PR DESCRIPTION
While using the Java client `sh.ory.kratos:kratos-client:0.5.4-alpha.1` I noticed that the `whoami` endpoint wasn't working. Saw it was being sent as part of the query. :)

This doesn't regenerate the client though - I'm assuming it has to be done manually. We should consider doing it as part of the build :\