### PR TITLE
fix: add missing 'passkey' enum to identity credentials

### DIFF
--- a/src/main/java/sh/ory/kratos/model/IdentityCredentials.java
+++ b/src/main/java/sh/ory/kratos/model/IdentityCredentials.java
@@ -80,6 +80,8 @@ public class IdentityCredentials {
     LOOKUP_SECRET("lookup_secret"),
     
     WEBAUTHN("webauthn"),
+
+    PASSKEY("passkey"),
     
     CODE("code"),
     


### PR DESCRIPTION

This PR addresses a missing enum in the kratos-client Java library. Previously, the library did not support the mapping of the `passkey` credential in Identity objects. This could lead to issues when trying to handle `passkey` credentials in identities.

Changes:
- Added the missing enum type to support `passkey` credential mapping in Identity objects.
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
